### PR TITLE
Update file paths for WordPress and MySQL volumes in Docker Compose

### DIFF
--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
     volumes:
-      - ./wordpress/resources:/var/www/html
+      - ./resources/wordpress:/var/www/html
       - ./wordpress/.htaccess:/var/www/html/.htaccess
       - ./wordpress/ads.txt:/var/www/html/ads.txt
 
@@ -27,4 +27,4 @@ services:
       MYSQL_PASSWORD: examplepass
       MYSQL_ROOT_PASSWORD: rootpass
     volumes:
-      - ./db/resources:/var/lib/mysql
+      - ./resources/db:/var/lib/mysql


### PR DESCRIPTION
This pull request updates the file paths for the WordPress and MySQL volumes in the Docker Compose file. The paths have been changed to `./resources/wordpress` for the WordPress volume and `./resources/db` for the MySQL volume. This change ensures that the volumes are correctly mounted in the containers.