### PR TITLE
Update file paths for WordPress and MySQL volumes in Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 resources/
-
-ads.txt

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     volumes:
       - ./resources/wordpress:/var/www/html
       - ./wordpress/.htaccess:/var/www/html/.htaccess
-      - ./wordpress/ads.txt:/var/www/html/ads.txt
 
   db:
     image: mysql:5.7


### PR DESCRIPTION
This pull request updates the file paths for the WordPress and MySQL volumes in the Docker Compose file. The `ads.txt` file is no longer included in the WordPress volume.